### PR TITLE
CdmaServiceStateTracker: Load CarrierConfig for NV Subscription

### DIFF
--- a/src/java/com/android/internal/telephony/cdma/CdmaServiceStateTracker.java
+++ b/src/java/com/android/internal/telephony/cdma/CdmaServiceStateTracker.java
@@ -54,6 +54,7 @@ import com.android.internal.telephony.CommandsInterface;
 import com.android.internal.telephony.CommandsInterface.RadioState;
 import com.android.internal.telephony.EventLogTags;
 import com.android.internal.telephony.ICarrierConfigLoader;
+import com.android.internal.telephony.IccCardConstants;
 import com.android.internal.telephony.MccTable;
 import com.android.internal.telephony.Phone;
 import com.android.internal.telephony.PhoneConstants;
@@ -325,6 +326,7 @@ public class CdmaServiceStateTracker extends ServiceStateTracker {
 
         case EVENT_NV_READY:
             updatePhoneObject();
+            updateCarrierConfig();
 
             // Only support automatic selection mode in CDMA.
             mCi.getNetworkSelectionMode(obtainMessage(EVENT_POLL_STATE_NETWORK_SELECTION_MODE));
@@ -2109,6 +2111,10 @@ public class CdmaServiceStateTracker extends ServiceStateTracker {
         Rlog.e(LOG_TAG, "[CdmaSST] " + s);
     }
 
+    protected void loge(String s, Throwable t) {
+        Rlog.e(LOG_TAG, "[CdmaSST] " + s, t);
+    }
+
     @Override
     public void dump(FileDescriptor fd, PrintWriter pw, String[] args) {
         pw.println("CdmaServiceStateTracker extends:");
@@ -2168,4 +2174,23 @@ public class CdmaServiceStateTracker extends ServiceStateTracker {
         }
         mImsRegistrationOnOff = registered;
     }
+
+    private void updateCarrierConfig(){
+        ICarrierConfigLoader configLoader =
+                (ICarrierConfigLoader) ServiceManager.getService(Context.CARRIER_CONFIG_SERVICE);
+
+        if (configLoader != null) {
+            try {
+                int phoneId = PhoneFactory.getDefaultPhone().getPhoneId();
+                configLoader.updateConfigForPhoneId(phoneId,
+                    IccCardConstants.INTENT_VALUE_ICC_LOADED);
+                log("updateCarrierConfig: CarrierConfig Updated for Phone ID " + phoneId);
+            } catch (Exception e) {
+                loge("updateCarrierConfig: An Error Occurred While Updating the CarrierConfig!", e);
+            }
+        } else {
+            log("updateCarrierConfig: no carrier config service available");
+        }
+    }
+
 }


### PR DESCRIPTION
Currently CDMA devices using an NV subscription end up with the
default set of CarrierConfig values, leading to many wrong
behaviors as their vendor overrides do not get loaded.

This is because the CarrierConfig is loaded based on the SIM
events, which are not issued for NV since its not a SIM card.

This patch triggers the CarrierConfig to be loaded on the
NV_READY event. This fixes many buggy behaviors for NV
subscriptions, most notably in the mobile network settings
menu, where things such as the world_phone menu and APN
settings menu could be drawn incorrectly or not at all for
the device, despite the correct overrides being set.

Change-Id: I1fde4f520d94bc88479a6b10c19c23518bbf7e78